### PR TITLE
Split consume/produce into 2 separate commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,62 @@
 
 Kafkacli is a consumer and producer client for Apache Kafka.
 
-### Usage:
+## Usage:
 ```
-kafkacli [-b] -t... [--from-beginning] [-g] [-m] [-h...]
+Usage: kafkacli [-b...] [--ssl-cafile] [--ssl-certfile] [--ssl-keyfile] COMMAND [arg...]
 
-Options:
-  -b, --broker           brokers (default "localhost:9092")
-  -t, --topic            topic
+Kafkacli
+                       
+Options:               
+  -b, --broker         brokers (default ["localhost:9092"])
+  -s, --secure         use SSL
+      --ssl-cafile     filename of CA file to use in certificate verification (env $KAFKACLI_SSL_CA_FILE)
+      --ssl-certfile   filename of file in PEM format containing the client certificate (env $KAFKACLI_SSL_CERT_FILE)
+      --ssl-keyfile    filename containing the client private key (env $KAFKACLI_SSL_KEY_FILE)
+                       
+Commands:              
+  consume              consume and display messages from 1 or more topics
+  produce              produce a message into 1 or more topics
+                       
+Run 'kafkacli COMMAND --help' for more information on a command.
+```
+
+The options listed above must be set before the command, e.g:
+
+`kafkacli -b <broker> consume notification`
+
+### Consume:
+
+```
+kafkacli consume --help
+
+Usage: kafkacli consume [--from-beginning] [-g] [-e] [-p] TOPIC...
+
+consume and display messages from 1 or more topics
+                         
+Arguments:               
+  TOPIC                  topic(s) to consume from
+                         
+Options:                 
+  -p, --pretty-print     pretty print the messages
       --from-beginning   start with the earliest message
-  -g, --consumer-group   consumer group id
-  -m, --message          message message
-  -h, --header           message header <key=value>
+  -g, --consumer-group   consumer group id. If unset, a random one will be generated
+  -e, --exit             exit when last message received
+```
+
+### Produce
+
+```
+kafkacli produce --help
+
+Usage: kafkacli produce [-H...] [-m=<message|->] TOPIC...
+
+produce a message into 1 or more topics
+                  
+Arguments:        
+  TOPIC           topic(s) to consume from
+                  
+Options:          
+  -H, --header    message header <key=value>
+  -m, --message   message message
 ```

--- a/consume.go
+++ b/consume.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+
+	"github.com/Shopify/sarama"
+	cluster "github.com/bsm/sarama-cluster"
+	cli "github.com/jawher/mow.cli"
+	uuid "github.com/satori/go.uuid"
+)
+
+func consumeCmd(c *cli.Cmd) {
+	var (
+		prettyPrint        = c.BoolOpt("p pretty-print", false, "pretty print the messages")
+		fromBeginning      = c.BoolOpt("from-beginning", false, "start with the earliest message")
+		consumerGroupId    = c.StringOpt("g consumer-group", "", "consumer group id. If unset, a random one will be generated")
+		existOnLastMessage = c.BoolOpt("e exit", false, "exit when last message received")
+
+		topics = c.Strings(cli.StringsArg{
+			Name: "TOPIC",
+			Desc: "topic(s) to consume from",
+		})
+	)
+
+	c.Spec = "[--from-beginning] [-g] [-e] [-p] TOPIC..."
+
+	c.Action = func() {
+		cfg := config(*useSSL, *sslCAFile, *sslCertFile, *sslKeyFile)
+		consume(*cfg, *bootstrapServers, *topics, *prettyPrint, *fromBeginning, *consumerGroupId, *existOnLastMessage)
+	}
+}
+
+func consume(config cluster.Config, bootstrapServers []string, topics []string, prettyPrint bool, fromBeginning bool, consumerGroupId string, existOnLastMessage bool) {
+	fmt.Printf("Consuming from topic(s) %q, broker(s) %q\n", strings.Join(topics, ", "), strings.Join(bootstrapServers, ", "))
+
+	if fromBeginning {
+		config.Consumer.Offsets.Initial = sarama.OffsetOldest
+	}
+
+	if consumerGroupId == "" {
+		uuidString := uuid.NewV4().String()
+		consumerGroupId = uuidString
+	}
+	consumer, err := cluster.NewConsumer(bootstrapServers, consumerGroupId, topics, &config)
+	die(err)
+
+	defer func() {
+		if err := consumer.Close(); err != nil {
+			log.Printf("error while closing consumer: %+v\n", err)
+		}
+	}()
+
+	// trap SIGINT to trigger a shutdown.
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt)
+
+	// consume errors
+	go func() {
+		for err := range consumer.Errors() {
+			fmt.Printf("Error: %v\n", err)
+		}
+	}()
+
+	startConsuming := make(chan struct{})
+	var partitionToRead int
+
+	// consume notifications
+	go func() {
+		for ntf := range consumer.Notifications() {
+			fmt.Printf("Rebalanced: %+v\n", ntf)
+			if len(ntf.Claimed) != 0 {
+				for _, topic := range ntf.Claimed {
+					partitionToRead += len(topic)
+				}
+				startConsuming <- struct{}{}
+			}
+		}
+	}()
+
+	// consume messages, watch signals
+	<-startConsuming
+
+	var messageCount int
+
+	for {
+		select {
+		case msg, ok := <-consumer.Messages():
+			if ok {
+				if prettyPrint {
+					displayMessagePretty(msg)
+				} else {
+					displayMessageUgly(msg)
+				}
+				messageCount++
+				marks := consumer.HighWaterMarks()
+				if existOnLastMessage && msg.Offset+1 == marks[msg.Topic][msg.Partition] {
+					partitionToRead -= 1
+				}
+			}
+		case <-signals:
+			partitionToRead = 0
+		}
+
+		if partitionToRead == 0 {
+			break
+		}
+	}
+	log.Printf("%d messages received\n", messageCount)
+}
+
+func displayMessagePretty(msg *sarama.ConsumerMessage) {
+	fmt.Printf("---------------- [%v] %s/%d ----------------\n", msg.Timestamp, msg.Topic, msg.Partition)
+	fmt.Printf("(Headers):\n")
+	for _, header := range msg.Headers {
+		fmt.Printf("- %q: %s\n", header.Key, header.Value)
+	}
+	if msg.Key != nil {
+		fmt.Printf("\n(Key): %s\n", msg.Key)
+	}
+	fmt.Printf("\n(Payload):\n%s\n\n", msg.Value)
+}
+
+func displayMessageUgly(msg *sarama.ConsumerMessage) {
+	fmt.Printf("[%s] %s/%d----------------\n", msg.Timestamp, msg.Topic, msg.Partition)
+	fmt.Printf("Headers:")
+	for _, header := range msg.Headers {
+		fmt.Printf(" %s=%s", header.Key, header.Value)
+	}
+	fmt.Printf("\n")
+	fmt.Printf("Message")
+	if msg.Key != nil {
+		fmt.Printf("[%s]%", msg.Key)
+	}
+	fmt.Printf(": %s\n", msg.Value)
+}

--- a/consume.go
+++ b/consume.go
@@ -30,7 +30,7 @@ func consumeCmd(c *cli.Cmd) {
 
 	c.Action = func() {
 		cfg := config(*useSSL, *sslCAFile, *sslCertFile, *sslKeyFile)
-		consume(*cfg, *bootstrapServers, *topics, *prettyPrint, *fromBeginning, *consumerGroupId, *existOnLastMessage)
+		consume(*cfg, splitFlatten(*bootstrapServers), splitFlatten(*topics), *prettyPrint, *fromBeginning, *consumerGroupId, *existOnLastMessage)
 	}
 }
 

--- a/consume.go
+++ b/consume.go
@@ -116,7 +116,7 @@ func displayMessagePretty(msg *sarama.ConsumerMessage) {
 	fmt.Printf("---------------- [%v] %s/%d ----------------\n", msg.Timestamp, msg.Topic, msg.Partition)
 	fmt.Printf("(Headers):\n")
 	for _, header := range msg.Headers {
-		fmt.Printf("- %q: %s\n", header.Key, header.Value)
+		fmt.Printf("- %q: %q\n", header.Key, header.Value)
 	}
 	if msg.Key != nil {
 		fmt.Printf("\n(Key): %s\n", msg.Key)

--- a/kafkacli.go
+++ b/kafkacli.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/Shopify/sarama"
 	cluster "github.com/bsm/sarama-cluster"
@@ -97,4 +98,15 @@ func die(err error) {
 		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		cli.Exit(1)
 	}
+}
+
+func splitFlatten(cs []string) []string {
+	var res []string
+	for _, c := range cs {
+		parts := strings.Split(c, ",")
+		for _, p := range parts {
+			res = append(res, strings.TrimSpace(p))
+		}
+	}
+	return res
 }

--- a/produce.go
+++ b/produce.go
@@ -33,7 +33,7 @@ func produceCmd(c *cli.Cmd) {
 		if *message == "" || *message == "-" {
 			*message = readStdin()
 		}
-		produce(*cfg, *bootstrapServers, *topics, *headers, *message)
+		produce(*cfg, splitFlatten(*bootstrapServers), splitFlatten(*topics), *headers, *message)
 	}
 }
 

--- a/produce.go
+++ b/produce.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/Shopify/sarama"
+	cluster "github.com/bsm/sarama-cluster"
+	cli "github.com/jawher/mow.cli"
+	"github.com/pkg/errors"
+)
+
+func produceCmd(c *cli.Cmd) {
+	var (
+		headers = c.StringsOpt("H header", nil, "message header <key=value>")
+		message = c.StringOpt("m message", "", "message message")
+
+		topics = c.Strings(cli.StringsArg{
+			Name: "TOPIC",
+			Desc: "topic(s) to consume from",
+		})
+	)
+
+	c.Spec = "[-H...] [-m=<message|->] TOPIC..."
+
+	c.Action = func() {
+		cfg := config(*useSSL, *sslCAFile, *sslCertFile, *sslKeyFile)
+
+		if *message == "" || *message == "-" {
+			*message = readStdin()
+		}
+		produce(*cfg, *bootstrapServers, *topics, *headers, *message)
+	}
+}
+
+func produce(config cluster.Config, bootstrapServers []string, topics []string, headers []string, message string) {
+	producer, err := sarama.NewSyncProducer(bootstrapServers, &config.Config)
+	die(err)
+
+	defer func() {
+		if err := producer.Close(); err != nil {
+			log.Printf("error while closing producer: %+v\n", err)
+		}
+	}()
+
+	var kafkaHeaders []sarama.RecordHeader
+	for _, element := range headers {
+		headerKeyValue := strings.Split(element, "=")
+		if len(headerKeyValue) != 2 {
+			die(errors.New("Invalid header param"))
+		}
+
+		headerKey := headerKeyValue[0]
+		headerValue := headerKeyValue[1]
+
+		newHeader := sarama.RecordHeader{
+			Key:   []byte(headerKey),
+			Value: []byte(headerValue),
+		}
+		kafkaHeaders = append(kafkaHeaders, newHeader)
+	}
+
+	for _, topic := range topics {
+		kafkaMessage := sarama.ProducerMessage{
+			Topic:   topic,
+			Headers: kafkaHeaders,
+			Value:   sarama.StringEncoder(message),
+		}
+
+		fmt.Printf("Send msg to topic %q:\n", topic)
+		if len(kafkaHeaders) > 0 {
+			fmt.Printf("(Headers):\n")
+			for _, h := range kafkaHeaders {
+				fmt.Printf("- %q: %q\n", h.Key, h.Value)
+			}
+		}
+		fmt.Printf("(Payload):\n---\n%s\n---\n", message)
+		_, _, err = producer.SendMessage(&kafkaMessage)
+		if err != nil {
+			fmt.Printf("error: %+v\n", err)
+		}
+	}
+}
+
+func readStdin() string {
+	info, err := os.Stdin.Stat()
+	if err != nil {
+		die(err)
+	}
+
+	if info.Mode()&os.ModeNamedPipe == 0 {
+		die(errors.Errorf(`a message body must be specified, either using -m="message content" or by piping the content: echo "message content | kafkacli send topic"`))
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	var output strings.Builder
+
+	for {
+		input, _, err := reader.ReadRune()
+		if err != nil && err == io.EOF {
+			break
+		}
+		output.WriteRune(input)
+	}
+
+	return output.String()
+}


### PR DESCRIPTION
## Call samples:

### Consume:

`kafkacli -b <broker> consume --pretty-print  <topic1>  <topic1>`

### Produce:

`echo "lol" | kafkacli -b <broker> produce  -H <key>=<value> <topic>`

`cat payload.json | kafkacli -b <broker> produce  -H T<key>=<value> <topic>`

`kafkacli -b <broker> produce  -H <key>=<value> -m="<payload>" <topic>`

## Pretty print
Also, rework the message formatting to (optionally) handle pretty print:

Sample output:

```
---------------- [2019-04-23 17:04:14.687 +0200 CEST]  <topic>/<partition> ----------------
(Headers):
- "Key": "Value"
- "X-Correlation-Id": "7c2cff80-8ea3-4c34-ae72-ef20190be4be"
- "PAYLOAD_TYPE": "TESt"

(Payload):
>big blob of text>
```