### PR TITLE
Replace undefined printf specifier by new line

### DIFF
--- a/consume.go
+++ b/consume.go
@@ -152,7 +152,7 @@ func displayMessageUgly(msg *sarama.ConsumerMessage) {
 	fmt.Printf("\n")
 	fmt.Printf("Message")
 	if msg.Key != nil {
-		fmt.Printf("[%s]%", msg.Key)
+		fmt.Printf("[%s]", msg.Key)
 	}
 	fmt.Printf(": %s\n", msg.Value)
 }


### PR DESCRIPTION
Replace unnecessary ```%``` by ```\n``` when we display partition key without pretty option. 

