### PR TITLE
Add SSL param in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Read all messages from 'my-topic' topic and filter messages when header key1 equ
 Use env var to define the default broker:
 
     $ KAFKACLI_BROKER=localhost:9092 kafkacli consume my-topic
+    
+Use SSL file to access secured broker:
+
+    $ kafkacli --ssl-cafile ca.pem --ssl-keyfile service.key --ssl-certfile service.cert -b my-secured-broker consume my-topic
 
 #### Producer
 


### PR DESCRIPTION
I saw that we can pass some SSL parameter but it was not documented in README.
I added an example for this case